### PR TITLE
using i18n.dtr instead of i18n.tr

### DIFF
--- a/modules/Ubuntu/Components/Extras/PhotoEditor.qml
+++ b/modules/Ubuntu/Components/Extras/PhotoEditor.qml
@@ -40,7 +40,7 @@ Item {
     property list<Action> toolActions: [
         Action {
             objectName: "cropButton"
-            text: i18n.tr("Crop")
+            text: i18n.dtr("ubuntu-ui-extras", "Crop")
             iconSource: Qt.resolvedUrl("PhotoEditor/assets/edit_crop.png")
             onTriggered: {
                 photoData.isLongOperation = false;
@@ -49,7 +49,7 @@ Item {
         },
         Action {
             objectName: "rotateButton"
-            text: i18n.tr("Rotate")
+            text: i18n.dtr("ubuntu-ui-extras", "Rotate")
             iconSource: Qt.resolvedUrl("PhotoEditor/assets/edit_rotate_right.png")
             onTriggered: {
                 photoData.isLongOperation = false;
@@ -193,8 +193,8 @@ Item {
           Dialog {
               id: revertPrompt
               objectName: "revertPromptDialog"
-              title: i18n.tr("Revert to original")
-              text: i18n.tr("This will undo all edits, including those from previous sessions.")
+              title: i18n.dtr("ubuntu-ui-extras", "Revert to original")
+              text: i18n.dtr("ubuntu-ui-extras", "This will undo all edits, including those from previous sessions.")
 
               Row {
                   id: row
@@ -203,13 +203,13 @@ Item {
                   Button {
                       objectName: "cancelRevertButton"
                       width: parent.width/2
-                      text: i18n.tr("Cancel")
+                      text: i18n.dtr("ubuntu-ui-extras", "Cancel")
                       onClicked: PopupUtils.close(revertPrompt)
                   }
                   Button {
                       objectName: "confirmRevertButton"
                       width: parent.width/2
-                      text: i18n.tr("Revert Photo")
+                      text: i18n.dtr("ubuntu-ui-extras", "Revert Photo")
                       color: UbuntuColors.green
                       onClicked: {
                           PopupUtils.close(revertPrompt)
@@ -223,7 +223,7 @@ Item {
     BusyIndicator {
         id: busyIndicator
         anchors.centerIn: parent
-        text: i18n.tr("Enhancing photo...")
+        text: i18n.dtr("ubuntu-ui-extras", "Enhancing photo...")
         running: photoData.busy
         longOperation: photoData.isLongOperation
     }


### PR DESCRIPTION
#3 Translated strings from ubuntu-ui-extras don't show translated inside the gallery app.

Now translation works like expected.
![screenshot20190411_094822451](https://user-images.githubusercontent.com/35935077/55941551-b70a1900-5c42-11e9-84c8-8260e0fb30bd.png)

