### PR TITLE
Main action arranged on the right and Cancel now has a neutral color

### DIFF
--- a/modules/Ubuntu/Components/Extras/PhotoEditor/ExposureAdjuster.qml
+++ b/modules/Ubuntu/Components/Extras/PhotoEditor/ExposureAdjuster.qml
@@ -69,22 +69,22 @@ Rectangle {
             anchors.horizontalCenter: parent.horizontalCenter
             spacing: units.gu(2)
             Button {
+                text: i18n.dtr("ubuntu-ui-extras", "Cancel")
+                gradient: UbuntuColors.greyGradient
+                enabled: adjuster.enabled
+                onTriggered: {
+                    targetImage.source = "";
+                    cancel();
+                }
+            }
+            Button {
                 text: i18n.dtr("ubuntu-ui-extras", "Done")
                 color: UbuntuColors.green
                 enabled: adjuster.enabled
                 onTriggered: {
                     targetImage.source = "";
                     confirm();
-                }
-            }
-            Button {
-                text: i18n.dtr("ubuntu-ui-extras", "Cancel")
-                color: UbuntuColors.red
-                enabled: adjuster.enabled
-                onTriggered: {
-                    targetImage.source = "";
-                    cancel();
-                }
+                }              
             }
         }
     }


### PR DESCRIPTION
@cibersheep  has pointed out to me that the arrangement and color of the buttons here does not correspond to the standard.

About the buttons, have in mind that we usually:

- color  the main action (red if it's destructive, green if positive) but avoid coloring both.
- Make clear message of what the action is doing. So, instead of Fertig, I would say Scale. Abbrechen is good :)
- Main action goes to the right (or top) so I suggest: [neutral color Abbrechen] [green color Scale] order

So i made some small changes
Before
![56136418-0d54c000-5f93-11e9-8fbe-ac060118c556](https://user-images.githubusercontent.com/35935077/56271691-5faff100-60f9-11e9-89ba-398d63f1f949.png)
Now
![screenshot20190417_094615714_edit](https://user-images.githubusercontent.com/35935077/56271718-6fc7d080-60f9-11e9-8914-659a99f95a05.png)

